### PR TITLE
[FIX] Use the addons path already parsed by odoo to loockup the parse…

### DIFF
--- a/report_aeroo/report_xml.py
+++ b/report_aeroo/report_xml.py
@@ -39,6 +39,7 @@ import openerp.netsvc as netsvc
 from report_aeroo import Aeroo_report
 from openerp.report.report_sxw import rml_parse
 from openerp.report import interface
+from openerp.modules import module
 import base64, binascii
 import openerp.tools as tools
 import encodings
@@ -107,12 +108,7 @@ class report_xml(models.Model):
         expected_class = 'Parser'
 
         try:
-            ad = os.path.abspath(os.path.join(tools.ustr(config['root_path']), u'addons'))
-            mod_path_list = map(lambda m: os.path.abspath(tools.ustr(m.strip())), config['addons_path'].split(','))
-            mod_path_list.append(ad)
-            mod_path_list = list(set(mod_path_list))
-
-            for mod_path in mod_path_list:
+            for mod_path in module.ad_paths:
                 if os.path.lexists(mod_path+os.path.sep+path.split(os.path.sep)[0]):
                     filepath = mod_path+os.path.sep+path
                     filepath = os.path.normpath(filepath)


### PR DESCRIPTION
…r_loc

This change is required to make the module compatible with PIP (https://github.com/acsone/setuptools-odoo and https://github.com/acsone/odoo-autodiscover)